### PR TITLE
Remove non-ascii character from the Modulefile

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -1,7 +1,7 @@
 name 'cmuench-n98magerun'
 version '0.5.2'
 source 'git://github.com/cmuench/puppet-n98magerun'
-author 'Christian Münch'
+author 'Christian Munch'
 license 'MIT'
 summary 'n98-magerun Magento CLI Tool'
 description 'n98-magerun Magento CLI Tool'


### PR DESCRIPTION
Info: Retrieving pluginfacts
Error: /File[/var/lib/puppet/facts.d]: Failed to generate additional resources using 'eval_generate': Error 400 on SERVER: "\xC3" on US-ASCII
Error: /File[/var/lib/puppet/facts.d]: Could not evaluate: Could not retrieve file metadata for puppet://puppet/pluginfacts: Error 400 on SERVER: "\xC3" on US-ASCII
Info: Retrieving plugin
Error: /File[/var/lib/puppet/lib]: Failed to generate additional resources using 'eval_generate': Error 400 on SERVER: "\xC3" on US-ASCII
Error: /File[/var/lib/puppet/lib]: Could not evaluate: Could not retrieve file metadata for puppet://puppet/plugins: Error 400 on SERVER: "\xC3" on US-ASCII
Info: Loading facts
Error: Could not retrieve catalog from remote server: Error 400 on SERVER: "\xC3" on US-ASCII at /var/lib/rg_data/puppet/environments/unstable/manifests/init.pp:13 on node devvm-vdeygas
Warning: Not using cache on failed catalog
Error: Could not retrieve catalog; skipping run
